### PR TITLE
org_limiter : remove service bindings, route mappings and orphans

### DIFF
--- a/org_limit.go
+++ b/org_limit.go
@@ -66,9 +66,18 @@ func (c *OrgLimit) Execute(_ []string) error {
 
 	for _, app := range toDelete {
 		RunParallel(app.Guid, func(meta interface{}) error {
+			err := cleanupAppRoutes(meta.(string))
+			if err != nil {
+				return err
+			}
+			err = cleanupAppServices(meta.(string))
+			if err != nil {
+				return err
+			}
 			return client.DeleteApp(meta.(string))
 		})
 	}
+
 	errors := WaitParallel()
 	if len(errors) > 0 {
 		fmt.Println("There is error when deleting apps:")
@@ -76,7 +85,141 @@ func (c *OrgLimit) Execute(_ []string) error {
 			fmt.Printf("\t- %s\n", err.Error())
 		}
 	}
+
+	err = c.cleanupOrphanRoutes(org.Guid)
+	if err != nil {
+		fmt.Println("Error while cleanup orphan's routes:" + err.Error())
+	}
+	err = c.cleanupOrphanServices(org.Guid)
+	if err != nil {
+		fmt.Println("Error while cleanup orphan's service instance:" + err.Error())
+	}
+
 	fmt.Println("Modifications has been applied.")
+	return nil
+}
+
+func cleanupAppRoutes(appGUID string) error {
+	client, err := retrieveClient()
+	if err != nil {
+		return err
+	}
+	routeMappings, err := client.ListRouteMappingsByQuery(url.Values{
+		"q": []string{"app_guid:" + appGUID},
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, routeMapping := range routeMappings {
+		err := client.DeleteRouteMapping(routeMapping.Guid)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanupAppServices(appGUID string) error {
+	client, err := retrieveClient()
+	if err != nil {
+		return err
+	}
+	serviceBindings, err := client.ListServiceBindingsByQuery(url.Values{
+		"q": []string{"app_guid:" + appGUID},
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, serviceBinding := range serviceBindings {
+		err := client.DeleteServiceBinding(serviceBinding.Guid)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *OrgLimit) cleanupOrphanRoutes(orgGUID string) error {
+	initParallel()
+	client, err := retrieveClient()
+	if err != nil {
+		return err
+	}
+	routes, err := client.ListRoutesByQuery(url.Values{
+		"q": []string{"organization_guid:" + orgGUID},
+	})
+	if err != nil {
+		return err
+	}
+	for _, route := range routes {
+		createdAt, _ := time.Parse(time.RFC3339, route.CreatedAt)
+		if createdAt.Add(time.Duration(c.TimeLimit)).Before(time.Now()) {
+			RunParallel(route.Guid, func(meta interface{}) error {
+				result, err := client.ListAppsByRoute((meta.(string)))
+				if err != nil {
+					return err
+				}
+				if len(result) == 0 {
+					return client.DeleteRoute(meta.(string))
+				}
+				return nil
+			})
+		}
+	}
+
+	errors := WaitParallel()
+	if len(errors) > 0 {
+		fmt.Println("There is error when deleting route :")
+		for _, err := range errors {
+			fmt.Printf("\t- %s\n", err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (c *OrgLimit) cleanupOrphanServices(orgGUID string) error {
+	initParallel()
+	client, err := retrieveClient()
+	if err != nil {
+		return err
+	}
+	serviceInstances, err := client.ListServiceInstancesByQuery(url.Values{
+		"q": []string{"organization_guid:" + orgGUID},
+	})
+	if err != nil {
+		return err
+	}
+	for _, serviceInstance := range serviceInstances {
+		createdAt, _ := time.Parse(time.RFC3339, serviceInstance.CreatedAt)
+		if createdAt.Add(time.Duration(c.TimeLimit)).Before(time.Now()) {
+			RunParallel(serviceInstance.Guid, func(meta interface{}) error {
+				result, err := client.ListServiceBindingsByQuery(url.Values{
+					"q": []string{"service_instance_guid:" + (meta.(string))},
+				})
+				if err != nil {
+					return err
+				}
+				if len(result) == 0 {
+					return client.DeleteServiceInstance(meta.(string), true, true)
+				}
+				return nil
+			})
+		}
+	}
+
+	errors := WaitParallel()
+	if len(errors) > 0 {
+		fmt.Println("There is error when deleting service instance :")
+		for _, err := range errors {
+			fmt.Printf("\t- %s\n", err.Error())
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
With org_limiter,
Services bindings and route mappings must be removed before deleting apps !

After removing apps, we clean orphan's service instances and routes
 